### PR TITLE
docs(get-started): 为服务器开发者快速入门指南添加选项卡组件

### DIFF
--- a/content/docs/(get-started)/quick-start/server-developers.mdx
+++ b/content/docs/(get-started)/quick-start/server-developers.mdx
@@ -45,6 +45,9 @@ MCP服务器可以提供三种主要功能：
 #### 设置你的环境变量
 使用 [Spring Initizer](https://start.spring.io) 启动项目。
 你需要添加以下的依赖项：
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+
 <Tabs items={['Maven', 'Gradle']}>
     <Tab value="Maven">
         ```xml


### PR DESCRIPTION
- 在服务器开发者快速入门指南中引入了 Fumadocs UI 组件库的选项卡（Tabs）功能
- 正确添加了 Maven 和 Gradle 作为选项卡的示例内容